### PR TITLE
feat: automatically detect the version when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ artifacts:
     type: local
 ```
 
+If the 'version' is not provided, sbomber will attempt to detect it based on the artifact:
+- `charm`, `snap`, `dist`, and `wheel` by extracting the version from the filename
+- `deb` by querying the `apt` tool
+- `rock` cannot be detected, so must be provided in the manifest
 
 ### Configuring the clients
 
@@ -109,7 +113,7 @@ artifacts:
     channel: 'latest/stable'
     ssdlc_params:
       name: jhack  # this is the name to report under, it may differ from the artifact
-      version: '461'  # typically the same as the artifact version
+      version: '461'  # typically the same as the artifact version, set to "" to auto-detect
       channel: 'stable'  # note that this is only the risk component
       cycle: '25.04'
 ```

--- a/src/sbomber.py
+++ b/src/sbomber.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -45,6 +46,10 @@ SECSCAN_KEY = "secscan"
 
 class InvalidStateTransitionError(Exception):
     """Raised if you run sbomber commands in an inconsistent order."""
+
+
+class IncompleteSSDLCParamsError(Exception):
+    """Raised if you do not have values for all four SSDLC ID params."""
 
 
 def _download_cmd(bin: str, artifact: Artifact):
@@ -285,6 +290,65 @@ def _download_artifact(artifact: Artifact):
     return obj_name
 
 
+def _detect_version(artifact: Artifact, obj_name: str) -> str | None:
+    """Detect the version of the artifact based on its name."""
+    obj_name = os.path.basename(obj_name)
+    if artifact.type is ArtifactType.charm and "_" in obj_name:
+        # The charm file should have a filename like:
+        # parca-k8s_r363.charm
+        try:
+            return obj_name.rsplit("_", 1)[-1].rsplit(".", 1)[0][1:]
+        except IndexError:
+            pass
+    if artifact.type is ArtifactType.deb:
+        # The version is in the name, but we can also ask apt for it.
+        apt = subprocess.run(
+            ["apt", "info", obj_name],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        # Example output:
+        # Package: cowsay
+        # Version: 3.03+dfsg2-8
+        # Priority: optional
+        for line in apt.stdout.splitlines():
+            if line.startswith("Version:"):
+                return line.split(":", 1)[1].strip()
+    elif artifact.type is ArtifactType.rock:
+        # We need the version to download the rock, so cannot automatically detect it.
+        # If the artifact is local rather than downloaded, we cannot know what filename the user
+        # has chosen, so we'll need them to provide it in the manifest.
+        pass
+    elif artifact.type is ArtifactType.snap and "_" in obj_name:
+        # We can ask snap for information, but it only includes the version, and we actually want
+        # the revision. That seems to only be in the filename, which looks like:
+        # concierge_40.snap
+        try:
+            return obj_name.rsplit("_", 1)[-1].rsplit(".", 1)[0]
+        except IndexError:
+            pass
+    elif artifact.type is ArtifactType.sdist and "-" in obj_name:
+        # The sdist file should have a filename like:
+        # ops_scenario-8.0.0.tar.gz
+        try:
+            return obj_name.rsplit(".", 2)[0].rsplit("-", 1)[-1]
+        except IndexError:
+            pass
+    elif artifact.type is ArtifactType.wheel:
+        # The wheel file should have a filename like:
+        # ops_scenario-8.0.0-py3-none-any.whl
+        wheel_re = (
+            r"^(?P<distribution>.+)-(?P<version>.+?)(?:-[^-.]+)*-"
+            r"(?P<python_tag>.+?)-(?P<abi_tag>.+?)-(?P<platform_tag>.+?)\.whl$"
+        )
+        mo = re.match(wheel_re, obj_name)
+        if mo:
+            return mo.group("version")
+    logger.info("Unable to detect version for %s (%s)", artifact, obj_name)
+    return None
+
+
 def prepare(
     manifest: Path = DEFAULT_MANIFEST,
     statefile: Path = DEFAULT_STATEFILE,
@@ -344,12 +408,24 @@ def prepare(
         else:
             print(f"downloading source {name}")
             try:
-                # TODO: could guess the revision/version number from the downloaded filename:
-                #   e.g. `mycharm-k8s_r42.charm` or `jhack_443.snap`
                 obj_name = _download_artifact(artifact)
             except (ValueError, CalledProcessError, DownloadError):
                 logger.exception(f"failed downloading {artifact.name}")
                 status = ProcessingStatus.error
+
+        if (
+            not artifact.version
+            and obj_name
+            and (obj_version := _detect_version(artifact, obj_name))
+        ):
+            artifact.version = obj_version
+            if artifact.ssdlc_params and not artifact.ssdlc_params.version:
+                artifact.ssdlc_params.version = obj_version
+        if artifact.ssdlc_params and not artifact.ssdlc_params.version:
+            # We failed to auto-detect, and there's nothing manually provided.
+            raise IncompleteSSDLCParamsError(
+                f"Missing SSDLC version for artifact {artifact.name}. Declare `{artifact.name}.ssdlc_params.version` in {manifest}"
+            )
 
         artifact.object = obj_name
         done.append((name, status))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,20 @@ def mock_package_download(
                 Successfully downloaded {name}
             """)
             (package_dir / f"{name}-1.0.0{ext}").write_text("ceci est une python package")
+        elif cmd[:2] == ["snap", "info"]:
+            mm.stdout = stdout or textwrap.dedent(f"""
+                name: {name}
+                version: 1.0.0
+                summary: A snap package
+            """)
+            (package_dir / f"{name}_1.0.0.snap").write_text("ceci est une snap package")
+        elif cmd[:2] == ["apt", "info"]:
+            mm.stdout = stdout or textwrap.dedent(f"""
+                Package: {name}
+                Version: 1.0.0
+                Priority: optional
+            """)
+            (package_dir / f"{name}.deb").write_text("ceci est une deb package")
         else:
             raise ValueError(f"Unknown command: {cmd}")
         return mm

--- a/tests/test_sbomb_client.py
+++ b/tests/test_sbomb_client.py
@@ -41,6 +41,7 @@ def test_prepare_statefile(project, tmp_path, sbomber_get_mock, sbomber_post_moc
                 "name": "foo",
                 "object": "parca-k8s_r299.charm",
                 "type": "charm",
+                "version": "299",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
                     "secscan": {"step": "prepare", "status": "Succeeded"},
@@ -70,6 +71,7 @@ def test_prepare_statefile(project, tmp_path, sbomber_get_mock, sbomber_post_moc
                 "name": "qux",
                 "object": "parca-k8s_r299.charm-1.0.0-py3-none-any.whl",
                 "type": "wheel",
+                "version": "1.0.0",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
                     "secscan": {"step": "prepare", "status": "Succeeded"},
@@ -78,6 +80,7 @@ def test_prepare_statefile(project, tmp_path, sbomber_get_mock, sbomber_post_moc
             {
                 "name": "quux",
                 "object": "parca-k8s_r299.charm-1.0.0.tar.gz",
+                "version": "1.0.0",
                 "type": "sdist",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
@@ -111,6 +114,7 @@ def test_prepare(project, tmp_path):
                 "name": "foo",
                 "object": "parca-k8s_r299.charm",
                 "type": "charm",
+                "version": "299",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
                     "secscan": {"step": "prepare", "status": "Succeeded"},
@@ -140,6 +144,7 @@ def test_prepare(project, tmp_path):
                 "name": "qux",
                 "object": "parca-k8s_r299.charm-1.0.0-py3-none-any.whl",
                 "type": "wheel",
+                "version": "1.0.0",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
                     "secscan": {"step": "prepare", "status": "Succeeded"},
@@ -149,6 +154,7 @@ def test_prepare(project, tmp_path):
                 "name": "quux",
                 "object": "parca-k8s_r299.charm-1.0.0.tar.gz",
                 "type": "sdist",
+                "version": "1.0.0",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
                     "secscan": {"step": "prepare", "status": "Succeeded"},

--- a/tests/test_version_detection.py
+++ b/tests/test_version_detection.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+from sbomber import _detect_version
+from state import Artifact, ArtifactType
+
+
+def test_detect_version_charm():
+    artifact = Artifact(name="parca-k8s", type=ArtifactType.charm)
+    assert _detect_version(artifact, "parca-k8s_r363.charm") == "363"
+
+
+def test_detect_version_deb():
+    artifact = Artifact(
+        name="cowsay", type=ArtifactType.deb, variant="universe", arch="amd64", base="jammy"
+    )
+    mock_output = "Package: cowsay\nVersion: 3.03+dfsg2-8\nPriority: optional"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=mock_output)
+        assert _detect_version(artifact, "cowsay.deb") == "3.03+dfsg2-8"
+        mock_run.assert_called_with(
+            ["apt", "info", "cowsay.deb"], capture_output=True, text=True, check=True
+        )
+
+
+def test_detect_version_rock():
+    artifact = Artifact(name="myrock", type=ArtifactType.rock)
+    assert _detect_version(artifact, "myrock_1.2.3.rock") is None
+
+
+def test_detect_version_snap():
+    artifact = Artifact(name="concierge", type=ArtifactType.snap)
+    assert _detect_version(artifact, "concierge_40.snap") == "40"
+
+
+def test_detect_version_sdist():
+    artifact = Artifact(name="ops_scenario", type=ArtifactType.sdist)
+    assert _detect_version(artifact, "ops_scenario-8.0.0.tar.gz") == "8.0.0"
+
+
+def test_detect_version_wheel():
+    artifact = Artifact(name="ops_scenario", type=ArtifactType.wheel)
+    assert _detect_version(artifact, "ops_scenario-8.0.0-py3-none-any.whl") == "8.0.0"


### PR DESCRIPTION
If a value for the `version` field is not provided (for example, downloading a snap based on the channel, or a local file) try to detect the version automatically.

For debs, use `apt info` to get the version. For charms, snaps, wheels, and sdists, extract the version from the filename. For rocks, we don't know what filename to expect other than in the case that we downloaded it, and to do that we had to have the version provided, so it doesn't seem possible to detect a version.

Also copy this value into the ID params if the other params are set.

This makes it simpler to use the tool in CI where the artefact has been produced and published in the CI run.