### PR TITLE
feat: add the ability to use a pattern for the local source

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ artifacts:
 
   - name: parka-k8s
     type: charm
-    source: /home/pietro/canonical/parca-k8s-operator/parca-k8s_ubuntu@24.04-amd64.charm
+    source: ~/canonical/parca-k8s-operator/
+    source_glob: 'parca-k8s_ubuntu@*.charm'  # Must match exactly one file in 'source' directory
     # default: use all clients
 ```
 

--- a/examples/all/manifest.yaml
+++ b/examples/all/manifest.yaml
@@ -21,8 +21,9 @@ artifacts:
     source: /path/to/parca-k8s-operator/parca-k8s_ubuntu@24.04-amd64.charm
     type: charm
 
-  - name: traefik_2.9.6_amd64.rock
-    source: /path/to/traefik-rock/traefik_2.9.6_amd64.rock
+  - name: traefik
+    source: /path/to/traefik-rock/
+    source_glob: 'traefik_*_amd64.rock'  # must match exactly one file in the 'source' directory
     type: rock
 
   - name: vim

--- a/src/state.py
+++ b/src/state.py
@@ -209,6 +209,7 @@ class Artifact(pydantic.BaseModel):
     name: str
     type: ArtifactType
     source: Optional[str] = None
+    source_glob: Optional[str] = None
     clients: Optional[List[str]] = None  # list of client names enabled for this artifact
     version: Optional[str] = None  # for charms and snaps, this maps to 'revision'
     base: Optional[str] = None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -69,7 +69,7 @@ def mock_dev_env(
 ):
     """Setup a temporary folder with some stuff pretending to be a valid sbomber project."""
 
-    def _mock_artifact(artifact, local: bool = True):
+    def _mock_artifact(artifact, local: bool = True, globbed: bool | None = None):
         name, type = artifact["name"], artifact["type"]
         if type == "wheel":
             pkg = f"{name}-1.0.0-py3-none-any.whl"
@@ -79,7 +79,11 @@ def mock_dev_env(
         if local:
             src = project / pkg
             src.write_text(content)
-            artifact["source"] = str(src)
+            if globbed:
+                artifact["source"] = str(src.parent)
+                artifact["source_glob"] = f"*.{type}"
+            else:
+                artifact["source"] = str(src)
 
         if step:
             (project / DEFAULT_PACKAGE_DIR).mkdir(exist_ok=True)
@@ -106,6 +110,8 @@ def mock_dev_env(
         ]
     )
 
-    for artifact, local in zip(artifacts, (False, True, True, False, False)):
-        _mock_artifact(artifact, local=local)
+    for artifact, local, globbed in zip(
+        artifacts, (False, True, True, False, False), (None, False, True, None, None)
+    ):
+        _mock_artifact(artifact, local=local, globbed=globbed)
     mock_manifest(project, artifacts, statefile=statefile, step=step, status=status)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -13,7 +13,8 @@ def test_manifest_load(tmp_path):
         type: charm
 
       - name: bar-k8s.rock
-        source: /bar/rock.rock
+        source: /bar/
+        source_glob: '*.rock'
         type: rock
 
       - name: baz-k8s

--- a/tests/test_sbomb_client.py
+++ b/tests/test_sbomb_client.py
@@ -60,7 +60,8 @@ def test_prepare_statefile(project, tmp_path, sbomber_get_mock, sbomber_post_moc
             {
                 "name": "baz",
                 "object": str(tmp_path / "baz.snap"),
-                "source": str(tmp_path / "baz.snap"),
+                "source": str(tmp_path),
+                "source_glob": "*.snap",
                 "type": "snap",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
@@ -133,7 +134,8 @@ def test_prepare(project, tmp_path):
             {
                 "name": "baz",
                 "object": str(tmp_path / "baz.snap"),
-                "source": str(tmp_path / "baz.snap"),
+                "source": str(tmp_path),
+                "source_glob": "*.snap",
                 "type": "snap",
                 "processing": {
                     "sbom": {"step": "prepare", "status": "Succeeded"},
@@ -233,7 +235,8 @@ def test_submit(project, tmp_path, sbomber_get_mock, sbomber_post_mock, secscann
                         "token": "secscan-token",
                     },
                 },
-                "source": str(tmp_path / "baz.snap"),
+                "source": str(tmp_path),
+                "source_glob": "*.snap",
                 "type": "snap",
             },
             {
@@ -343,7 +346,8 @@ def test_poll(project, tmp_path, sbomber_get_mock, secscanner_run_mock):
                         "token": "secscan-token",
                     },
                 },
-                "source": str(tmp_path / "baz.snap"),
+                "source": str(tmp_path),
+                "source_glob": "*.snap",
                 "type": "snap",
             },
             {


### PR DESCRIPTION
In CI, the artifact might not yet be available from the store (after publishing to PyPI, for example, it can take a few minutes before the new release shows up), so it's more robust to use the local file produced in the workflow. However, it's awkward with the parallel workflow to use the `source` field with the full filename when the filename contains a version (or base or revision, etc).

This PR adds a new field `source_glob`. When set:
* The `source` field specifies a directory rather than a specific file.
* sbomber will look for files matching the glob in the source directory.
* If there's exactly one matching file, then it's used as the source (exactly as if you'd specified that file in `source`).
* If there are zero or multiple matching files, then we error out.

Drive-by fix: correct the local/source example in the README.