### PR TITLE
sbomber: fix deb version determination

### DIFF
--- a/src/sbomber.py
+++ b/src/sbomber.py
@@ -303,9 +303,9 @@ def _detect_version(artifact: Artifact, obj_name: str) -> str | None:
         except IndexError:
             pass
     if artifact.type is ArtifactType.deb:
-        # The version is in the name, but we can also ask apt for it.
+        # The version is in the name, but we better ask dpkg for it.
         apt = subprocess.run(
-            ["apt", "info", obj_name],
+            ["dpkg-deb", "-I", DEFAULT_PACKAGE_DIR / obj_name],
             capture_output=True,
             text=True,
             check=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def mock_package_download(
                 summary: A snap package
             """)
             (package_dir / f"{name}_1.0.0.snap").write_text("ceci est une snap package")
-        elif cmd[:2] == ["apt", "info"]:
+        elif cmd[:2] == ["dpkg-deb", "-I"]:
             mm.stdout = stdout or textwrap.dedent(f"""
                 Package: {name}
                 Version: 1.0.0

--- a/tests/test_version_detection.py
+++ b/tests/test_version_detection.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+from pathlib import PosixPath
+
 from sbomber import _detect_version
 from state import Artifact, ArtifactType
 
@@ -19,7 +21,7 @@ def test_detect_version_deb():
         mock_run.return_value = MagicMock(stdout=mock_output)
         assert _detect_version(artifact, "cowsay.deb") == "3.03+dfsg2-8"
         mock_run.assert_called_with(
-            ["apt", "info", "cowsay.deb"], capture_output=True, text=True, check=True
+            ["dpkg-deb", "-I", PosixPath("pkgs/cowsay.deb")], capture_output=True, text=True, check=True
         )
 
 


### PR DESCRIPTION
`apt` operates on package repositories, not package files.