### PR TITLE
state: make `version` optional

### DIFF
--- a/src/state.py
+++ b/src/state.py
@@ -135,7 +135,7 @@ class SSDLCParams(pydantic.BaseModel):
 
     name: str
     """Product name, as found in the Security dashboard."""
-    version: str
+    version: Optional[str] = None
     """Product version, typically the same as the artifact version."""
     channel: str
     """Release channel, for example 'Edge', 'Stable'"""

--- a/tests/test_secscan_client.py
+++ b/tests/test_secscan_client.py
@@ -123,7 +123,7 @@ def test_scanner_args_sssdlc_params():
     "params",
     [
         {"version": "1.0", "channel": "stable", "cycle": "25.10"},
-        {"name": "test-product", "channel": "stable", "cycle": "25.10"},
+        # version is optional
         {"name": "test-product", "version": "1.0", "cycle": "25.10"},
         {"name": "test-product", "version": "1.0", "channel": "stable"},
     ],


### PR DESCRIPTION
Otherwise validation fails and nothing happens.