### PR TITLE
all: support overloading artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ artifacts:
   - name: parca-k8s
     version: 299
     type: charm
+    charm: parca-k8s    # defaults to $name
 
-  - name: jhack
+  - name: jhack-latest
+    snap: jhack         # defaults to $name
     type: snap
 
   - name: /home/pietro/canonical/parca-k8s-operator/parca-k8s_ubuntu@24.04-amd64.charm

--- a/src/sbomber.py
+++ b/src/sbomber.py
@@ -9,7 +9,7 @@ import subprocess
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
-from typing import Dict
+from typing import Dict, Optional
 
 import apt  # type: ignore
 from craft_archives.repo import apt_ppa
@@ -52,13 +52,15 @@ class IncompleteSSDLCParamsError(Exception):
     """Raised if you do not have values for all four SSDLC ID params."""
 
 
-def _download_cmd(bin: str, artifact: Artifact):
+def _download_cmd(bin: str, artifact: Artifact, item: Optional[str] = None):
+    if item is None:
+        item = artifact.name
     channel_arg = f" --channel {channel}" if (channel := artifact.channel) else ""
     revision_arg = f" --revision {revision}" if (revision := artifact.version) else ""
     base_arg = f" --base {base}" if bin == "juju" and (base := artifact.base) else ""
     progress_arg = " --no-progress" if bin == "juju" else ""
     return shlex.split(
-        f"{bin} download {artifact.name}{progress_arg}{channel_arg}{revision_arg}{base_arg}"
+        f"{bin} download {item}{progress_arg}{channel_arg}{revision_arg}{base_arg}"
     )
 
 
@@ -90,7 +92,7 @@ def _download_rock(artifact: Artifact) -> str:
 
 def _download_charm(artifact: Artifact) -> str:
     """Download a charm from the charm store."""
-    cmd = _download_cmd("juju", artifact)
+    cmd = _download_cmd("juju", artifact, artifact.charm)
     proc = subprocess.run(cmd, capture_output=True, text=True)
     # example output is:
     # Fetching charm "parca-k8s" revision 299
@@ -111,7 +113,7 @@ def _download_charm(artifact: Artifact) -> str:
 
 def _download_snap(artifact: Artifact) -> str:
     """Download a snap from the snap store."""
-    cmd = _download_cmd("snap", artifact)
+    cmd = _download_cmd("snap", artifact, artifact.snap)
     proc = subprocess.run(cmd, capture_output=True, text=True)
 
     # example output is:
@@ -207,11 +209,11 @@ def _download_deb(artifact: Artifact) -> str:
         assert cache.update(), "Failed to update apt cache"
 
         cache.open()
-        # ?
-        package = cache[artifact.package].candidate
+        # apt-get info <pkg-name>
+        package = cache[artifact.package or artifact.name].candidate
         assert package is not None, "Failed to find package"
 
-        # apt-get source <pkg-name>
+        # apt-get download <pkg-name>
         obj_name = Path(package.fetch_binary()).name
         cache.close()
 
@@ -229,7 +231,7 @@ def _download_from_pypi(artifact: Artifact) -> str:
         cmd.append("--only-binary=:all:")
     elif artifact.type is ArtifactType.sdist:
         cmd.append("--no-binary=:all:")
-    cmd.append(artifact.name)
+    cmd.append(artifact.package or artifact.name)
     if artifact.version:
         cmd[-1] += f"=={artifact.version}"
 

--- a/src/sbomber.py
+++ b/src/sbomber.py
@@ -92,7 +92,8 @@ def _download_rock(artifact: Artifact) -> str:
 
 def _download_charm(artifact: Artifact) -> str:
     """Download a charm from the charm store."""
-    cmd = _download_cmd("juju", artifact, artifact.charm)
+    charm_name_to_download = artifact.charm or artifact.name
+    cmd = _download_cmd("juju", artifact, charm_name_to_download)
     proc = subprocess.run(cmd, capture_output=True, text=True)
     # example output is:
     # Fetching charm "parca-k8s" revision 299
@@ -105,7 +106,7 @@ def _download_charm(artifact: Artifact) -> str:
     charm_name = proc.stderr.strip().splitlines()[-1].split()[-1][2:]
 
     # if this doesn't look like a charm name, something bad happened
-    if not (charm_name.startswith(artifact.name) and charm_name.endswith(".charm")):
+    if not (charm_name.startswith(charm_name_to_download) and charm_name.endswith(".charm")):
         logger.error("error fetching charm from juju with %s", cmd)
         raise DownloadError(proc.stderr)
     return charm_name
@@ -390,7 +391,8 @@ def prepare(
             )
             continue
 
-        name = f"{artifact.name}-{artifact.type.value}"
+        channel_suffix = f"-{artifact.channel.replace('/', '-')}" if artifact.channel else ""
+        name = f"{artifact.name}{channel_suffix}-{artifact.type.value}"
 
         if name in artifact_name_and_type:
             logger.error(f"Artifact name {name} is not unique: skipping...")
@@ -700,7 +702,8 @@ def download(statefile: Path = DEFAULT_STATEFILE, reports_dir=DEFAULT_REPORTS_DI
                 )
 
             extension = "html" if client_name == "secscan" else "json"
-            filename = f"{artifact_name}-{artifact.type.value}.{client_name}.{extension}"
+            channel_part = f"-{artifact.channel.replace('/', '-')}" if artifact.channel else ""
+            filename = f"{artifact_name}{channel_part}-{artifact.type.value}.{client_name}.{extension}"
 
             done.append((f"({client_name}):{artifact.name}", filename))
 

--- a/src/sbomber.py
+++ b/src/sbomber.py
@@ -59,9 +59,7 @@ def _download_cmd(bin: str, artifact: Artifact, item: Optional[str] = None):
     revision_arg = f" --revision {revision}" if (revision := artifact.version) else ""
     base_arg = f" --base {base}" if bin == "juju" and (base := artifact.base) else ""
     progress_arg = " --no-progress" if bin == "juju" else ""
-    return shlex.split(
-        f"{bin} download {item}{progress_arg}{channel_arg}{revision_arg}{base_arg}"
-    )
+    return shlex.split(f"{bin} download {item}{progress_arg}{channel_arg}{revision_arg}{base_arg}")
 
 
 def _download_rock(artifact: Artifact) -> str:
@@ -703,7 +701,9 @@ def download(statefile: Path = DEFAULT_STATEFILE, reports_dir=DEFAULT_REPORTS_DI
 
             extension = "html" if client_name == "secscan" else "json"
             channel_part = f"-{artifact.channel.replace('/', '-')}" if artifact.channel else ""
-            filename = f"{artifact_name}{channel_part}-{artifact.type.value}.{client_name}.{extension}"
+            filename = (
+                f"{artifact_name}{channel_part}-{artifact.type.value}.{client_name}.{extension}"
+            )
 
             done.append((f"({client_name}):{artifact.name}", filename))
 

--- a/src/state.py
+++ b/src/state.py
@@ -216,13 +216,17 @@ class Artifact(pydantic.BaseModel):
     ssdlc_params: Optional[SSDLCParams] = None
 
     # specific for charms
+    charm: Optional[str] = None
     channel: Optional[str] = None
 
     # specific for OCI images
     image: Optional[str] = None
 
+    # specific for snaps
+    snap: Optional[str] = None
+
     # specific for debs
-    package: Optional[str] = None
+    package: Optional[str] = None  # also for wheels
     arch: Optional[str] = None  # also for wheels
     variant: Optional[str] = None
     pocket: Optional[str] = None  # todo: is this mandatory for debs?

--- a/src/state.py
+++ b/src/state.py
@@ -216,14 +216,14 @@ class Artifact(pydantic.BaseModel):
     ssdlc_params: Optional[SSDLCParams] = None
 
     # specific for charms
-    charm: Optional[str] = None
+    charm: Optional[str] = None  # actual charm name to download; defaults to `name`
     channel: Optional[str] = None
 
     # specific for OCI images
     image: Optional[str] = None
 
     # specific for snaps
-    snap: Optional[str] = None
+    snap: Optional[str] = None  # actual snap name to download; defaults to `name`
 
     # specific for debs
     package: Optional[str] = None  # also for wheels

--- a/tests/test_sbomb_client.py
+++ b/tests/test_sbomb_client.py
@@ -1,15 +1,19 @@
+from unittest.mock import MagicMock, patch
+
 import yaml
 
 from sbomber import (
     DEFAULT_PACKAGE_DIR,
+    DEFAULT_REPORTS_DIR,
     DEFAULT_STATEFILE,
+    download,
     poll,
     prepare,
     submit,
 )
 from state import ProcessingStatus, ProcessingStep
 from tests.conftest import mock_package_download
-from tests.helpers import mock_dev_env
+from tests.helpers import mock_dev_env, mock_manifest
 
 
 def test_prepare_collect(project, sbomber_get_mock, sbomber_post_mock):
@@ -391,3 +395,99 @@ def test_poll(project, tmp_path, sbomber_get_mock, secscanner_run_mock):
             "secscan": {},
         },
     }
+
+
+def test_prepare_charm_name_override(project, sbomber_get_mock, sbomber_post_mock):
+    """When charm: is set, juju downloads using that store name, not the display name."""
+    artifacts = [
+        {
+            "name": "alertmanager-k8s-2",
+            "charm": "alertmanager-k8s",
+            "channel": "2/edge",
+            "type": "charm",
+        }
+    ]
+    mock_manifest(project, artifacts)
+
+    with mock_package_download(project, "alertmanager-k8s_r299.charm") as mm:
+        prepare()
+
+    # juju was called with the store charm name, not the display name
+    juju_cmd = mm.call_args_list[0].args[0]
+    assert juju_cmd[:3] == ["juju", "download", "alertmanager-k8s"]
+    assert "alertmanager-k8s-2" not in juju_cmd
+
+    # statefile preserves the display name and the charm override
+    sf = yaml.safe_load((project / DEFAULT_STATEFILE).read_text())
+    assert sf["artifacts"][0]["name"] == "alertmanager-k8s-2"
+    assert sf["artifacts"][0]["charm"] == "alertmanager-k8s"
+    assert sf["artifacts"][0]["processing"]["sbom"]["status"] == ProcessingStatus.success.value
+
+
+def test_prepare_snap_name_override(project, sbomber_get_mock, sbomber_post_mock):
+    """When snap: is set, snap downloads using that store name, not the display name."""
+    artifacts = [
+        {
+            "name": "jhack-latest",
+            "snap": "jhack",
+            "channel": "latest/stable",
+            "type": "snap",
+        }
+    ]
+    mock_manifest(project, artifacts)
+
+    snap_filename = "jhack_445.snap"
+
+    def subprocess_side_effect(cmd, *args, **kwargs):
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.stderr = ""
+        if cmd[0] == "snap":
+            mock.stdout = f"snap install {snap_filename}"
+            (project / snap_filename).write_text("ceci est une snap")
+        return mock
+
+    with patch("subprocess.run", side_effect=subprocess_side_effect) as mm:
+        prepare()
+
+    # snap was called with the store snap name, not the display name
+    snap_cmd = mm.call_args_list[0].args[0]
+    assert snap_cmd[:3] == ["snap", "download", "jhack"]
+    assert "jhack-latest" not in snap_cmd
+
+    # statefile preserves the display name and the snap override
+    sf = yaml.safe_load((project / DEFAULT_STATEFILE).read_text())
+    assert sf["artifacts"][0]["name"] == "jhack-latest"
+    assert sf["artifacts"][0]["snap"] == "jhack"
+    assert sf["artifacts"][0]["processing"]["sbom"]["status"] == ProcessingStatus.success.value
+
+
+def test_prepare_multi_channel_no_dedup(project, sbomber_get_mock, sbomber_post_mock):
+    """Two charms with the same name but different channels are both prepared."""
+    artifacts = [
+        {"name": "alertmanager-k8s", "channel": "2/edge", "type": "charm"},
+        {"name": "alertmanager-k8s", "channel": "dev/edge", "type": "charm"},
+    ]
+    mock_manifest(project, artifacts)
+
+    with mock_package_download(project, "alertmanager-k8s_r100.charm"):
+        prepare()
+
+    sf = yaml.safe_load((project / DEFAULT_STATEFILE).read_text())
+    assert len(sf["artifacts"]) == 2
+    assert {a.get("channel") for a in sf["artifacts"]} == {"2/edge", "dev/edge"}
+    for a in sf["artifacts"]:
+        assert a["processing"]["sbom"]["status"] == ProcessingStatus.success.value
+        assert a["processing"]["secscan"]["status"] == ProcessingStatus.success.value
+
+
+def test_download_filename_includes_channel(project, sbomber_get_mock, secscanner_run_mock):
+    """Report filenames include the channel slug when an artifact has a channel set."""
+    artifacts = [{"name": "alertmanager-k8s", "type": "charm", "channel": "2/edge"}]
+    mock_manifest(project, artifacts, step=ProcessingStep.submit, status=ProcessingStatus.success)
+
+    download()
+
+    reports_dir = project / DEFAULT_REPORTS_DIR
+    assert (reports_dir / "alertmanager-k8s-2-edge-charm.sbom.json").exists()
+    assert (reports_dir / "alertmanager-k8s-2-edge-charm.secscan.html").exists()


### PR DESCRIPTION
This so we can support multiple artifacts of the same entity (e.g. from different channels).